### PR TITLE
BUG: User free search was not working on the user list endpoint

### DIFF
--- a/app/api_v2/resources.py
+++ b/app/api_v2/resources.py
@@ -321,15 +321,17 @@ class UserList(Resource):
         users = User.search()
 
         if args['username']:
-            users = users.filter('term', username=args.username)
+            users = users.filter('wildcard', username__keyword=args.username+"*")
 
         if args['organization']:
-            users = users.filter('term', organization=args.organization)
+            users = users.filter('term', organization=args.organization)    
 
         if args.deleted:
             users = users.filter('match', deleted=True)
         else:
             users = users.filter('match', deleted=False)
+
+        print(users.to_dict())
 
         users, total_results, pages = page_results(users, args.page, args.page_size)
 

--- a/app/api_v2/utils.py
+++ b/app/api_v2/utils.py
@@ -118,8 +118,14 @@ def check_org(f):
     def wrapper(*args, **kwargs):
         if 'current_user' in kwargs:
             current_user = kwargs['current_user']
-            if current_user and not hasattr(current_user,'default_org') and args[0].api.payload and 'organization' in args[0].api.payload:
-                args[0].api.payload.pop('organization')
+            if current_user and not hasattr(current_user,'default_org'):
+                if len(args) > 0:
+                    try:
+                        if hasattr(args[0].api,'payload') and 'organization' in args[0].api.payload:
+                            print(args[0].api.payload)
+                            args[0].api.payload.pop('organization')
+                    except Exception as e:
+                        pass
         return f(*args, **kwargs)
     wrapper.__doc__ = f.__doc__
     wrapper.__name__ = f.__name__


### PR DESCRIPTION
BUG: When a sub-tenant would request an endpoint without a JSON payload and the check_org wrapper was used the API would return a 400 error complaining about no JSON being present