### PR TITLE
Bug Fixes

### DIFF
--- a/app/api_v2/model/threat.py
+++ b/app/api_v2/model/threat.py
@@ -212,7 +212,6 @@ class ThreatList(base.BaseDocument):
 
             found = False
 
-            
             if self.list_type != 'patterns':
                 hasher = hashlib.md5()
                 hasher.update(value.encode())

--- a/app/api_v2/resource/event_rule.py
+++ b/app/api_v2/resource/event_rule.py
@@ -646,7 +646,11 @@ class TestEventRQL(Resource):
                     organization = api.payload['organization']
             
             qp = QueryParser(organization=organization)
-            parsed_query = qp.parser.parse(api.payload['query'])
+            try:
+                parsed_query = qp.parser.parse(api.payload['query'])
+            except SyntaxError as e:
+                print(e.__dict__)
+                api.abort(400, f"Invalid RQL Query.  Please consult the RQL documentation for more information.")
             result = [r for r in qp.run_search(event_data, parsed_query)]
             hits = len(result)
 

--- a/app/api_v2/utils.py
+++ b/app/api_v2/utils.py
@@ -295,9 +295,12 @@ def check_password_reset_token(token):
     try:
         decoded_token = jwt.decode(token, current_app.config['SECRET_KEY'], algorithms=['HS256'])
 
-        expired = ExpiredToken.search().filter('term', token=token).execute()
-        if expired:
-            abort(401, 'Token retired.')
+        try:
+            expired = ExpiredToken.search().filter('term', token=token).execute()
+            if expired:
+                abort(401, 'Token retired.')
+        except Exception as e:
+            current_app.logger.error(f"Error checking for expired token: {e}")
 
         if 'type' in decoded_token and decoded_token['type'] in ['password_reset','mfa_challenge']:
             user = User.get_by_uuid(uuid=decoded_token['uuid'])
@@ -322,9 +325,13 @@ def _check_token():
         try:
             access_token = auth_header.split(' ')[1]
 
-            expired = ExpiredToken.search().filter('term', token=access_token).execute()
-            if expired:
-                abort(401, 'Token retired.')
+            try:
+                expired = ExpiredToken.search().filter('term', token=access_token).execute()
+                if expired:
+                    abort(401, 'Token retired.')
+            except Exception as e:
+                current_app.logger.error(f"Error checking for expired token: {e}")
+
             try:
                 token = jwt.decode(access_token, current_app.config['SECRET_KEY'], algorithms=['HS256'])
 

--- a/app/services/threat_list_poller/base.py
+++ b/app/services/threat_list_poller/base.py
@@ -394,7 +394,10 @@ class ThreatListPoller(object):
                             l.polled(time_taken=time_taken, poll_uuid=poll_uuid)
 
                         # Remove the old values after pushing the new values
-                        values.delete()
+                        try:
+                            values.delete()
+                        except Exception as e:
+                            self.logger.error(f"Failed to delete old values. {e}")
 
                         end_date = datetime.datetime.utcnow()
                         time_taken = (end_date - start_date).total_seconds()


### PR DESCRIPTION
- BUG: When EventWorkers would try to save a task and the save action would time out the Event Worker would crash
- BUG: When streaming_bulk had BulkIndexErrors they were unhandled and it would cause EventWorkers to crash
- BUG: When RQL syntax was incorrect and Test Rule was sent, the API would return Internal Server Error due to an unhandled exception
- BUG: When ExpiredTokens are searched and a timeout occurs there were unhandled exceptions by the API process
- BUG: When multiple Threat/Intel Pollers are running (this should never happen), some inflight delete_by_query calls would result in an unhandled exception in the Threat/Intel poller