### PR TITLE
Housekeeper Rule Additions

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -313,6 +313,20 @@ def create_app(environment='development'):
                 seconds=600
             )
 
+            if app.config['EVENT_RULE_SILENT_CHECK_ENABLED']:
+                scheduler.add_job(
+                    func=housekeeper.check_silent_event_rules,
+                    trigger="interval",
+                    seconds=app.config['EVENT_RULE_SILENT_INTERVAL']
+                )
+
+            if app.config['EVENT_RULE_HIGH_VOLUME_CHECK_ENABLED']:
+                scheduler.add_job(
+                    func=housekeeper.check_high_volume_event_rules,
+                    trigger="interval",
+                    seconds=app.config['EVENT_RULE_HIGH_VOLUME_INTERVAL']
+                )
+
         if not app.config['SLAMONITOR_DISABLED']:
             sla_monitor = SLAMonitor(app, log_level=app.config['SLAMONITOR_LOG_LEVEL'])
             scheduler.add_job(func=sla_monitor.check_event_slas, trigger="interval", seconds=app.config['SLAMONITOR_INTERVAL'])

--- a/app/api_v2/model/event.py
+++ b/app/api_v2/model/event.py
@@ -558,6 +558,8 @@ class EventRule(base.BaseDocument):
     notification_channels = Keyword() # The channels to send notifications to
     agent_uuid = Keyword() # The agent that created this event rule
     agent_type = Keyword() # The type of agent that created this event rule
+    high_volume_rule = Boolean() # This flags true if the Event rule is too noisy
+    tags = Keyword() # Descriptive tags for the event rule
 
     class Index: # pylint: disable=too-few-public-methods
         ''' Defines the index to use '''

--- a/config.py
+++ b/config.py
@@ -83,14 +83,14 @@ class Config(object):
 
     # Define Housekeeper settings for Silent Event Rule checks, default to 60 seconds, 7 days, 0 hits
     EVENT_RULE_SILENT_CHECK_ENABLED = as_bool(os.getenv('REFLEX_EVENT_RULE_SILENT_CHECK_ENABLED')) if os.getenv('REFLEX_EVENT_RULE_SILENT_CHECK_ENABLED') else False
-    EVENT_RULE_SILENT_INTERVAL = int(os.getenv('REFLEX_EVENT_RULE_SILENT_INTERVAL')) if os.getenv('REFLEX_EVENT_RULE_SILENT_INTERVAL') else 60 # Default to 60 seconds
-    EVENT_RULE_SILENT_DAYS = int(os.getenv('REFLEX_EVENT_RULE_SILENT_DAYS')) if os.getenv('REFLEX_EVENT_RULE_SILENT_DAYS') else 30 # Default to 7 days
+    EVENT_RULE_SILENT_INTERVAL = int(os.getenv('REFLEX_EVENT_RULE_SILENT_INTERVAL')) if os.getenv('REFLEX_EVENT_RULE_SILENT_INTERVAL') else 3600 # Default to 60 seconds
+    EVENT_RULE_SILENT_DAYS = int(os.getenv('REFLEX_EVENT_RULE_SILENT_DAYS')) if os.getenv('REFLEX_EVENT_RULE_SILENT_DAYS') else 30 # Default to 30 days
     EVENT_RULE_SILENT_HITS = int(os.getenv('REFLEX_EVENT_RULE_SILENT_HITS')) if os.getenv('REFLEX_EVENT_RULE_SILENT_HITS') else 0
 
     # Define Housekeeper settings for High Volume Event Rule checks, default to 60 seconds, 7 days, 10000 hits
     EVENT_RULE_HIGH_VOLUME_CHECK_ENABLED = as_bool(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_CHECK_ENABLED')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_CHECK_ENABLED') else False
-    EVENT_RULE_HIGH_VOLUME_INTERVAL = int(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_INTERVAL')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_INTERVAL') else 60 # Default to 60 seconds
-    EVENT_RULE_HIGH_VOLUME_DAYS = int(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_DAYS')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_DAYS') else 30 # Default to 7 days
+    EVENT_RULE_HIGH_VOLUME_INTERVAL = int(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_INTERVAL')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_INTERVAL') else 3600 # Default to 60 seconds
+    EVENT_RULE_HIGH_VOLUME_DAYS = int(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_DAYS')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_DAYS') else 30 # Default to 30 days
     EVENT_RULE_HIGH_VOLUME_HITS = int(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_HITS')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_HITS') else 10000
 
     # EVENT INGEST CONFIGURATION

--- a/config.py
+++ b/config.py
@@ -80,7 +80,18 @@ class Config(object):
     AGENT_HEALTH_CHECK_INPUT_INTERVAL = int(os.getenv('REFLEX_AGENT_HEALTH_INPUT_INTERVAL', 5))*60 # Defaults to 5 minutes
     TASK_PRUNE_INTERVAL = int(os.getenv('REFLEX_TASK_PRUNE_INTERVAL')) if os.getenv('REFLEX_TASK_PRUNE_INTERVAL') else 3600 # Default to every hour
     TASK_PRUNE_LIFETIME = int(os.getenv('REFLEX_TASK_PRUNE_LIFETIME')) if os.getenv('REFLEX_TASK_PRUNE_LIFETIME') else 30 # Default to 30 days
-    
+
+    # Define Housekeeper settings for Silent Event Rule checks, default to 60 seconds, 7 days, 0 hits
+    EVENT_RULE_SILENT_CHECK_ENABLED = as_bool(os.getenv('REFLEX_EVENT_RULE_SILENT_CHECK_ENABLED')) if os.getenv('REFLEX_EVENT_RULE_SILENT_CHECK_ENABLED') else False
+    EVENT_RULE_SILENT_INTERVAL = int(os.getenv('REFLEX_EVENT_RULE_SILENT_INTERVAL')) if os.getenv('REFLEX_EVENT_RULE_SILENT_INTERVAL') else 60 # Default to 60 seconds
+    EVENT_RULE_SILENT_DAYS = int(os.getenv('REFLEX_EVENT_RULE_SILENT_DAYS')) if os.getenv('REFLEX_EVENT_RULE_SILENT_DAYS') else 30 # Default to 7 days
+    EVENT_RULE_SILENT_HITS = int(os.getenv('REFLEX_EVENT_RULE_SILENT_HITS')) if os.getenv('REFLEX_EVENT_RULE_SILENT_HITS') else 0
+
+    # Define Housekeeper settings for High Volume Event Rule checks, default to 60 seconds, 7 days, 10000 hits
+    EVENT_RULE_HIGH_VOLUME_CHECK_ENABLED = as_bool(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_CHECK_ENABLED')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_CHECK_ENABLED') else False
+    EVENT_RULE_HIGH_VOLUME_INTERVAL = int(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_INTERVAL')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_INTERVAL') else 60 # Default to 60 seconds
+    EVENT_RULE_HIGH_VOLUME_DAYS = int(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_DAYS')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_DAYS') else 30 # Default to 7 days
+    EVENT_RULE_HIGH_VOLUME_HITS = int(os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_HITS')) if os.getenv('REFLEX_EVENT_RULE_HIGH_VOLUME_HITS') else 10000
 
     # EVENT INGEST CONFIGURATION
     EVENT_PROCESSING_THREADS = os.getenv('REFLEX_EVENT_PROCESSING_THREADS') if os.getenv('REFLEX_EVENT_PROCESSING_THREADS') else 1


### PR DESCRIPTION
Two new HouseKeeper rules have been added (default Off)

- check_silent_event_rules
- check_high_volume_event_rules

They are controlled by the following environment variables

REFLEX_EVENT_RULE_SILENT_CHECK_ENABLED - Default `False`
REFLEX_EVENT_RULE_SILENT_INTERVAL - Default `3600` seconds
REFLEX_EVENT_RULE_SILENT_DAYS - Default `30` days
REFLEX_EVENT_RULE_SILENT_HITS - Default `0` hits
REFLEX_EVENT_RULE_HIGH_VOLUME_CHECK_ENABLED - Default `False`
REFLEX_EVENT_RULE_HIGH_VOLUME_INTERVAL - Default `3600` seconds
REFLEX_EVENT_RULE_HIGH_VOLUME_DAYS - Default `30` days
REFLEX_EVENT_RULE_HIGH_VOLUME_HITS - Default `10000` hits