### PR TITLE
Support for e-mail notifications

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -60,6 +60,7 @@ urllib3 = "*"
 psutil = "*"
 diskcache = "*"
 secure = "*"
+markdown = "*"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5639a64631dec60468cdcfe7768920e2632989b8f5bdfb7a1d5e7a02a870650e"
+            "sha256": "5b5c689014edf34212b47abfd1e2b39ca52f6717871f99d40433f620db821331"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==9.0.1"
+        },
+        "anyio": {
+            "hashes": [
+                "sha256:44a3c9aba0f5defa43261a8b3efb97891f2bd7d804e0e1f56419befa1adfc780",
+                "sha256:91dee416e570e92c64041bd18b900d1d6fa78dff7048769ce5ac5ddad004fbb5"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.7.1"
         },
         "apscheduler": {
             "hashes": [
@@ -184,84 +192,84 @@
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:04afa6387e2b282cf78ff3dbce20f0cc071c12dc8f685bd40960cc68644cfea6",
-                "sha256:04eefcee095f58eaabe6dc3cc2262f3bcd776d2c67005880894f447b3f2cb9c1",
-                "sha256:0be65ccf618c1e7ac9b849c315cc2e8a8751d9cfdaa43027d4f6624bd587ab7e",
-                "sha256:0c95f12b74681e9ae127728f7e5409cbbef9cd914d5896ef238cc779b8152373",
-                "sha256:0ca564606d2caafb0abe6d1b5311c2649e8071eb241b2d64e75a0d0065107e62",
-                "sha256:10c93628d7497c81686e8e5e557aafa78f230cd9e77dd0c40032ef90c18f2230",
-                "sha256:11d117e6c63e8f495412d37e7dc2e2fff09c34b2d09dbe2bee3c6229577818be",
-                "sha256:11d3bcb7be35e7b1bba2c23beedac81ee893ac9871d0ba79effc7fc01167db6c",
-                "sha256:12a2b561af122e3d94cdb97fe6fb2bb2b82cef0cdca131646fdb940a1eda04f0",
-                "sha256:12d1a39aa6b8c6f6248bb54550efcc1c38ce0d8096a146638fd4738e42284448",
-                "sha256:1435ae15108b1cb6fffbcea2af3d468683b7afed0169ad718451f8db5d1aff6f",
-                "sha256:1c60b9c202d00052183c9be85e5eaf18a4ada0a47d188a83c8f5c5b23252f649",
-                "sha256:1e8fcdd8f672a1c4fc8d0bd3a2b576b152d2a349782d1eb0f6b8e52e9954731d",
-                "sha256:20064ead0717cf9a73a6d1e779b23d149b53daf971169289ed2ed43a71e8d3b0",
-                "sha256:21fa558996782fc226b529fdd2ed7866c2c6ec91cee82735c98a197fae39f706",
-                "sha256:22908891a380d50738e1f978667536f6c6b526a2064156203d418f4856d6e86a",
-                "sha256:3160a0fd9754aab7d47f95a6b63ab355388d890163eb03b2d2b87ab0a30cfa59",
-                "sha256:322102cdf1ab682ecc7d9b1c5eed4ec59657a65e1c146a0da342b78f4112db23",
-                "sha256:34e0a2f9c370eb95597aae63bf85eb5e96826d81e3dcf88b8886012906f509b5",
-                "sha256:3573d376454d956553c356df45bb824262c397c6e26ce43e8203c4c540ee0acb",
-                "sha256:3747443b6a904001473370d7810aa19c3a180ccd52a7157aacc264a5ac79265e",
-                "sha256:38e812a197bf8e71a59fe55b757a84c1f946d0ac114acafaafaf21667a7e169e",
-                "sha256:3a06f32c9634a8705f4ca9946d667609f52cf130d5548881401f1eb2c39b1e2c",
-                "sha256:3a5fc78f9e3f501a1614a98f7c54d3969f3ad9bba8ba3d9b438c3bc5d047dd28",
-                "sha256:3d9098b479e78c85080c98e1e35ff40b4a31d8953102bb0fd7d1b6f8a2111a3d",
-                "sha256:3dc5b6a8ecfdc5748a7e429782598e4f17ef378e3e272eeb1340ea57c9109f41",
-                "sha256:4155b51ae05ed47199dc5b2a4e62abccb274cee6b01da5b895099b61b1982974",
-                "sha256:49919f8400b5e49e961f320c735388ee686a62327e773fa5b3ce6721f7e785ce",
-                "sha256:53d0a3fa5f8af98a1e261de6a3943ca631c526635eb5817a87a59d9a57ebf48f",
-                "sha256:5f008525e02908b20e04707a4f704cd286d94718f48bb33edddc7d7b584dddc1",
-                "sha256:628c985afb2c7d27a4800bfb609e03985aaecb42f955049957814e0491d4006d",
-                "sha256:65ed923f84a6844de5fd29726b888e58c62820e0769b76565480e1fdc3d062f8",
-                "sha256:6734e606355834f13445b6adc38b53c0fd45f1a56a9ba06c2058f86893ae8017",
-                "sha256:6baf0baf0d5d265fa7944feb9f7451cc316bfe30e8df1a61b1bb08577c554f31",
-                "sha256:6f4f4668e1831850ebcc2fd0b1cd11721947b6dc7c00bf1c6bd3c929ae14f2c7",
-                "sha256:6f5c2e7bc8a4bf7c426599765b1bd33217ec84023033672c1e9a8b35eaeaaaf8",
-                "sha256:6f6c7a8a57e9405cad7485f4c9d3172ae486cfef1344b5ddd8e5239582d7355e",
-                "sha256:7381c66e0561c5757ffe616af869b916c8b4e42b367ab29fedc98481d1e74e14",
-                "sha256:73dc03a6a7e30b7edc5b01b601e53e7fc924b04e1835e8e407c12c037e81adbd",
-                "sha256:74db0052d985cf37fa111828d0dd230776ac99c740e1a758ad99094be4f1803d",
-                "sha256:75f2568b4189dda1c567339b48cba4ac7384accb9c2a7ed655cd86b04055c795",
-                "sha256:78cacd03e79d009d95635e7d6ff12c21eb89b894c354bd2b2ed0b4763373693b",
-                "sha256:80d1543d58bd3d6c271b66abf454d437a438dff01c3e62fdbcd68f2a11310d4b",
-                "sha256:830d2948a5ec37c386d3170c483063798d7879037492540f10a475e3fd6f244b",
-                "sha256:891cf9b48776b5c61c700b55a598621fdb7b1e301a550365571e9624f270c203",
-                "sha256:8f25e17ab3039b05f762b0a55ae0b3632b2e073d9c8fc88e89aca31a6198e88f",
-                "sha256:9a3267620866c9d17b959a84dd0bd2d45719b817245e49371ead79ed4f710d19",
-                "sha256:a04f86f41a8916fe45ac5024ec477f41f886b3c435da2d4e3d2709b22ab02af1",
-                "sha256:aaf53a6cebad0eae578f062c7d462155eada9c172bd8c4d250b8c1d8eb7f916a",
-                "sha256:abc1185d79f47c0a7aaf7e2412a0eb2c03b724581139193d2d82b3ad8cbb00ac",
-                "sha256:ac0aa6cd53ab9a31d397f8303f92c42f534693528fafbdb997c82bae6e477ad9",
-                "sha256:ac3775e3311661d4adace3697a52ac0bab17edd166087d493b52d4f4f553f9f0",
-                "sha256:b06f0d3bf045158d2fb8837c5785fe9ff9b8c93358be64461a1089f5da983137",
-                "sha256:b116502087ce8a6b7a5f1814568ccbd0e9f6cfd99948aa59b0e241dc57cf739f",
-                "sha256:b82fab78e0b1329e183a65260581de4375f619167478dddab510c6c6fb04d9b6",
-                "sha256:bd7163182133c0c7701b25e604cf1611c0d87712e56e88e7ee5d72deab3e76b5",
-                "sha256:c36bcbc0d5174a80d6cccf43a0ecaca44e81d25be4b7f90f0ed7bcfbb5a00909",
-                "sha256:c3af8e0f07399d3176b179f2e2634c3ce9c1301379a6b8c9c9aeecd481da494f",
-                "sha256:c84132a54c750fda57729d1e2599bb598f5fa0344085dbde5003ba429a4798c0",
-                "sha256:cb7b2ab0188829593b9de646545175547a70d9a6e2b63bf2cd87a0a391599324",
-                "sha256:cca4def576f47a09a943666b8f829606bcb17e2bc2d5911a46c8f8da45f56755",
-                "sha256:cf6511efa4801b9b38dc5546d7547d5b5c6ef4b081c60b23e4d941d0eba9cbeb",
-                "sha256:d16fd5252f883eb074ca55cb622bc0bee49b979ae4e8639fff6ca3ff44f9f854",
-                "sha256:d2686f91611f9e17f4548dbf050e75b079bbc2a82be565832bc8ea9047b61c8c",
-                "sha256:d7fc3fca01da18fbabe4625d64bb612b533533ed10045a2ac3dd194bfa656b60",
-                "sha256:dd5653e67b149503c68c4018bf07e42eeed6b4e956b24c00ccdf93ac79cdff84",
-                "sha256:de5695a6f1d8340b12a5d6d4484290ee74d61e467c39ff03b39e30df62cf83a0",
-                "sha256:e0ac8959c929593fee38da1c2b64ee9778733cdf03c482c9ff1d508b6b593b2b",
-                "sha256:e1b25e3ad6c909f398df8921780d6a3d120d8c09466720226fc621605b6f92b1",
-                "sha256:e633940f28c1e913615fd624fcdd72fdba807bf53ea6925d6a588e84e1151531",
-                "sha256:e89df2958e5159b811af9ff0f92614dabf4ff617c03a4c1c6ff53bf1c399e0e1",
-                "sha256:ea9f9c6034ea2d93d9147818f17c2a0860d41b71c38b9ce4d55f21b6f9165a11",
-                "sha256:f645caaf0008bacf349875a974220f1f1da349c5dbe7c4ec93048cdc785a3326",
-                "sha256:f8303414c7b03f794347ad062c0516cee0e15f7a612abd0ce1e25caf6ceb47df",
-                "sha256:fca62a8301b605b954ad2e9c3666f9d97f63872aa4efcae5492baca2056b74ab"
+                "sha256:04e57ab9fbf9607b77f7d057974694b4f6b142da9ed4a199859d9d4d5c63fe96",
+                "sha256:09393e1b2a9461950b1c9a45d5fd251dc7c6f228acab64da1c9c0165d9c7765c",
+                "sha256:0b87549028f680ca955556e3bd57013ab47474c3124dc069faa0b6545b6c9710",
+                "sha256:1000fba1057b92a65daec275aec30586c3de2401ccdcd41f8a5c1e2c87078706",
+                "sha256:1249cbbf3d3b04902ff081ffbb33ce3377fa6e4c7356f759f3cd076cc138d020",
+                "sha256:1920d4ff15ce893210c1f0c0e9d19bfbecb7983c76b33f046c13a8ffbd570252",
+                "sha256:193cbc708ea3aca45e7221ae58f0fd63f933753a9bfb498a3b474878f12caaad",
+                "sha256:1a100c6d595a7f316f1b6f01d20815d916e75ff98c27a01ae817439ea7726329",
+                "sha256:1f30b48dd7fa1474554b0b0f3fdfdd4c13b5c737a3c6284d3cdc424ec0ffff3a",
+                "sha256:203f0c8871d5a7987be20c72442488a0b8cfd0f43b7973771640fc593f56321f",
+                "sha256:246de67b99b6851627d945db38147d1b209a899311b1305dd84916f2b88526c6",
+                "sha256:2dee8e57f052ef5353cf608e0b4c871aee320dd1b87d351c28764fc0ca55f9f4",
+                "sha256:2efb1bd13885392adfda4614c33d3b68dee4921fd0ac1d3988f8cbb7d589e72a",
+                "sha256:2f4ac36d8e2b4cc1aa71df3dd84ff8efbe3bfb97ac41242fbcfc053c67434f46",
+                "sha256:3170c9399da12c9dc66366e9d14da8bf7147e1e9d9ea566067bbce7bb74bd9c2",
+                "sha256:3b1613dd5aee995ec6d4c69f00378bbd07614702a315a2cf6c1d21461fe17c23",
+                "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace",
+                "sha256:3bb7fda7260735efe66d5107fb7e6af6a7c04c7fce9b2514e04b7a74b06bf5dd",
+                "sha256:41b25eaa7d15909cf3ac4c96088c1f266a9a93ec44f87f1d13d4a0e86c81b982",
+                "sha256:45de3f87179c1823e6d9e32156fb14c1927fcc9aba21433f088fdfb555b77c10",
+                "sha256:46fb8c61d794b78ec7134a715a3e564aafc8f6b5e338417cb19fe9f57a5a9bf2",
+                "sha256:48021783bdf96e3d6de03a6e39a1171ed5bd7e8bb93fc84cc649d11490f87cea",
+                "sha256:4957669ef390f0e6719db3613ab3a7631e68424604a7b448f079bee145da6e09",
+                "sha256:5e86d77b090dbddbe78867a0275cb4df08ea195e660f1f7f13435a4649e954e5",
+                "sha256:6339d047dab2780cc6220f46306628e04d9750f02f983ddb37439ca47ced7149",
+                "sha256:681eb3d7e02e3c3655d1b16059fbfb605ac464c834a0c629048a30fad2b27489",
+                "sha256:6c409c0deba34f147f77efaa67b8e4bb83d2f11c8806405f76397ae5b8c0d1c9",
+                "sha256:7095f6fbfaa55defb6b733cfeb14efaae7a29f0b59d8cf213be4e7ca0b857b80",
+                "sha256:70c610f6cbe4b9fce272c407dd9d07e33e6bf7b4aa1b7ffb6f6ded8e634e3592",
+                "sha256:72814c01533f51d68702802d74f77ea026b5ec52793c791e2da806a3844a46c3",
+                "sha256:7a4826ad2bd6b07ca615c74ab91f32f6c96d08f6fcc3902ceeedaec8cdc3bcd6",
+                "sha256:7c70087bfee18a42b4040bb9ec1ca15a08242cf5867c58726530bdf3945672ed",
+                "sha256:855eafa5d5a2034b4621c74925d89c5efef61418570e5ef9b37717d9c796419c",
+                "sha256:8700f06d0ce6f128de3ccdbc1acaea1ee264d2caa9ca05daaf492fde7c2a7200",
+                "sha256:89f1b185a01fe560bc8ae5f619e924407efca2191b56ce749ec84982fc59a32a",
+                "sha256:8b2c760cfc7042b27ebdb4a43a4453bd829a5742503599144d54a032c5dc7e9e",
+                "sha256:8c2f5e83493748286002f9369f3e6607c565a6a90425a3a1fef5ae32a36d749d",
+                "sha256:8e098148dd37b4ce3baca71fb394c81dc5d9c7728c95df695d2dca218edf40e6",
+                "sha256:94aea8eff76ee6d1cdacb07dd2123a68283cb5569e0250feab1240058f53b623",
+                "sha256:95eb302ff792e12aba9a8b8f8474ab229a83c103d74a750ec0bd1c1eea32e669",
+                "sha256:9bd9b3b31adcb054116447ea22caa61a285d92e94d710aa5ec97992ff5eb7cf3",
+                "sha256:9e608aafdb55eb9f255034709e20d5a83b6d60c054df0802fa9c9883d0a937aa",
+                "sha256:a103b3a7069b62f5d4890ae1b8f0597618f628b286b03d4bc9195230b154bfa9",
+                "sha256:a386ebe437176aab38c041de1260cd3ea459c6ce5263594399880bbc398225b2",
+                "sha256:a38856a971c602f98472050165cea2cdc97709240373041b69030be15047691f",
+                "sha256:a401b4598e5d3f4a9a811f3daf42ee2291790c7f9d74b18d75d6e21dda98a1a1",
+                "sha256:a7647ebdfb9682b7bb97e2a5e7cb6ae735b1c25008a70b906aecca294ee96cf4",
+                "sha256:aaf63899c94de41fe3cf934601b0f7ccb6b428c6e4eeb80da72c58eab077b19a",
+                "sha256:b0dac0ff919ba34d4df1b6131f59ce95b08b9065233446be7e459f95554c0dc8",
+                "sha256:baacc6aee0b2ef6f3d308e197b5d7a81c0e70b06beae1f1fcacffdbd124fe0e3",
+                "sha256:bf420121d4c8dce6b889f0e8e4ec0ca34b7f40186203f06a946fa0276ba54029",
+                "sha256:c04a46716adde8d927adb9457bbe39cf473e1e2c2f5d0a16ceb837e5d841ad4f",
+                "sha256:c0b21078a4b56965e2b12f247467b234734491897e99c1d51cee628da9786959",
+                "sha256:c1c76a1743432b4b60ab3358c937a3fe1341c828ae6194108a94c69028247f22",
+                "sha256:c4983bf937209c57240cff65906b18bb35e64ae872da6a0db937d7b4af845dd7",
+                "sha256:c4fb39a81950ec280984b3a44f5bd12819953dc5fa3a7e6fa7a80db5ee853952",
+                "sha256:c57921cda3a80d0f2b8aec7e25c8aa14479ea92b5b51b6876d975d925a2ea346",
+                "sha256:c8063cf17b19661471ecbdb3df1c84f24ad2e389e326ccaf89e3fb2484d8dd7e",
+                "sha256:ccd16eb18a849fd8dcb23e23380e2f0a354e8daa0c984b8a732d9cfaba3a776d",
+                "sha256:cd6dbe0238f7743d0efe563ab46294f54f9bc8f4b9bcf57c3c666cc5bc9d1299",
+                "sha256:d62e51710986674142526ab9f78663ca2b0726066ae26b78b22e0f5e571238dd",
+                "sha256:db901e2ac34c931d73054d9797383d0f8009991e723dab15109740a63e7f902a",
+                "sha256:e03b8895a6990c9ab2cdcd0f2fe44088ca1c65ae592b8f795c3294af00a461c3",
+                "sha256:e1c8a2f4c69e08e89632defbfabec2feb8a8d99edc9f89ce33c4b9e36ab63037",
+                "sha256:e4b749b9cc6ee664a3300bb3a273c1ca8068c46be705b6c31cf5d276f8628a94",
+                "sha256:e6a5bf2cba5ae1bb80b154ed68a3cfa2fa00fde979a7f50d6598d3e17d9ac20c",
+                "sha256:e857a2232ba53ae940d3456f7533ce6ca98b81917d47adc3c7fd55dad8fab858",
+                "sha256:ee4006268ed33370957f55bf2e6f4d263eaf4dc3cfc473d1d90baff6ed36ce4a",
+                "sha256:eef9df1eefada2c09a5e7a40991b9fc6ac6ef20b1372abd48d2794a316dc0449",
+                "sha256:f058f6963fd82eb143c692cecdc89e075fa0828db2e5b291070485390b2f1c9c",
+                "sha256:f25c229a6ba38a35ae6e25ca1264621cc25d4d38dca2942a7fce0b67a4efe918",
+                "sha256:f2a1d0fd4242bd8643ce6f98927cf9c04540af6efa92323e9d3124f57727bfc1",
+                "sha256:f7560358a6811e52e9c4d142d497f1a6e10103d3a6881f18d04dbce3729c0e2c",
+                "sha256:f779d3ad205f108d14e99bb3859aa7dd8e9c68874617c72354d7ecaec2a054ac",
+                "sha256:f87f746ee241d30d6ed93969de31e5ffd09a2961a051e60ae6bddde9ec3583aa"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==3.1.0"
+            "version": "==3.2.0"
         },
         "chevron": {
             "hashes": [
@@ -273,11 +281,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
-                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+                "sha256:4be4b1af8d665c6d942909916d31a213a106800c47d0eeba73d34da3cbc11367",
+                "sha256:e576aa487d679441d7d30abb87e1b43d24fc53bffb8758443b1a9e1cee504548"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==8.1.3"
+            "version": "==8.1.5"
         },
         "colorama": {
             "hashes": [
@@ -289,28 +297,32 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:059e348f9a3c1950937e1b5d7ba1f8e968508ab181e75fc32b879452f08356db",
-                "sha256:1a5472d40c8f8e91ff7a3d8ac6dfa363d8e3138b961529c996f3e2df0c7a411a",
-                "sha256:1a8e6c2de6fbbcc5e14fd27fb24414507cb3333198ea9ab1258d916f00bc3039",
-                "sha256:1fee5aacc7367487b4e22484d3c7e547992ed726d14864ee33c0176ae43b0d7c",
-                "sha256:5d092fdfedaec4cbbffbf98cddc915ba145313a6fdaab83c6e67f4e6c218e6f3",
-                "sha256:5f0ff6e18d13a3de56f609dd1fd11470918f770c6bd5d00d632076c727d35485",
-                "sha256:7bfc55a5eae8b86a287747053140ba221afc65eb06207bedf6e019b8934b477c",
-                "sha256:7fa01527046ca5facdf973eef2535a27fec4cb651e4daec4d043ef63f6ecd4ca",
-                "sha256:8dde71c4169ec5ccc1087bb7521d54251c016f126f922ab2dfe6649170a3b8c5",
-                "sha256:8f4ab7021127a9b4323537300a2acfb450124b2def3756f64dc3a3d2160ee4b5",
-                "sha256:948224d76c4b6457349d47c0c98657557f429b4e93057cf5a2f71d603e2fc3a3",
-                "sha256:9a6c7a3c87d595608a39980ebaa04d5a37f94024c9f24eb7d10262b92f739ddb",
-                "sha256:b46e37db3cc267b4dea1f56da7346c9727e1209aa98487179ee8ebed09d21e43",
-                "sha256:b4ceb5324b998ce2003bc17d519080b4ec8d5b7b70794cbd2836101406a9be31",
-                "sha256:cb33ccf15e89f7ed89b235cff9d49e2e62c6c981a6061c9c8bb47ed7951190bc",
-                "sha256:d198820aba55660b4d74f7b5fd1f17db3aa5eb3e6893b0a41b75e84e4f9e0e4b",
-                "sha256:d34579085401d3f49762d2f7d6634d6b6c2ae1242202e860f4d26b046e3a1006",
-                "sha256:eb8163f5e549a22888c18b0d53d6bb62a20510060a22fd5a995ec8a05268df8a",
-                "sha256:f73bff05db2a3e5974a6fd248af2566134d8981fd7ab012e5dd4ddb1d9a70699"
+                "sha256:01f1d9e537f9a15b037d5d9ee442b8c22e3ae11ce65ea1f3316a41c78756b711",
+                "sha256:079347de771f9282fbfe0e0236c716686950c19dee1b76240ab09ce1624d76d7",
+                "sha256:182be4171f9332b6741ee818ec27daff9fb00349f706629f5cbf417bd50e66fd",
+                "sha256:192255f539d7a89f2102d07d7375b1e0a81f7478925b3bc2e0549ebf739dae0e",
+                "sha256:2a034bf7d9ca894720f2ec1d8b7b5832d7e363571828037f9e0c4f18c1b58a58",
+                "sha256:342f3767e25876751e14f8459ad85e77e660537ca0a066e10e75df9c9e9099f0",
+                "sha256:439c3cc4c0d42fa999b83ded80a9a1fb54d53c58d6e59234cfe97f241e6c781d",
+                "sha256:49c3222bb8f8e800aead2e376cbef687bc9e3cb9b58b29a261210456a7783d83",
+                "sha256:674b669d5daa64206c38e507808aae49904c988fa0a71c935e7006a3e1e83831",
+                "sha256:7a9a3bced53b7f09da251685224d6a260c3cb291768f54954e28f03ef14e3766",
+                "sha256:7af244b012711a26196450d34f483357e42aeddb04128885d95a69bd8b14b69b",
+                "sha256:7d230bf856164de164ecb615ccc14c7fc6de6906ddd5b491f3af90d3514c925c",
+                "sha256:84609ade00a6ec59a89729e87a503c6e36af98ddcd566d5f3be52e29ba993182",
+                "sha256:9a6673c1828db6270b76b22cc696f40cde9043eb90373da5c2f8f2158957f42f",
+                "sha256:9b6d717393dbae53d4e52684ef4f022444fc1cce3c48c38cb74fca29e1f08eaa",
+                "sha256:9c3fe6534d59d071ee82081ca3d71eed3210f76ebd0361798c74abc2bcf347d4",
+                "sha256:a719399b99377b218dac6cf547b6ec54e6ef20207b6165126a280b0ce97e0d2a",
+                "sha256:b332cba64d99a70c1e0836902720887fb4529ea49ea7f5462cf6640e095e11d2",
+                "sha256:d124682c7a23c9764e54ca9ab5b308b14b18eba02722b8659fb238546de83a76",
+                "sha256:d73f419a56d74fef257955f51b18d046f3506270a5fd2ac5febbfa259d6c0fa5",
+                "sha256:f0dc40e6f7aa37af01aba07277d3d64d5a03dc66d682097541ec4da03cc140ee",
+                "sha256:f14ad275364c8b4e525d018f6716537ae7b6d369c094805cae45300847e0894f",
+                "sha256:f772610fe364372de33d76edcd313636a25684edb94cee53fd790195f5989d14"
             ],
             "index": "pypi",
-            "version": "==41.0.1"
+            "version": "==41.0.2"
         },
         "defusedxml": {
             "hashes": [
@@ -337,11 +349,11 @@
         },
         "dnspython": {
             "hashes": [
-                "sha256:224e32b03eb46be70e12ef6d64e0be123a64e621ab4c0822ff6d450d52a540b9",
-                "sha256:89141536394f909066cabd112e3e1a37e4e654db00a25308b0f130bc3152eb46"
+                "sha256:46b4052a55b56beea3a3bdd7b30295c292bd6827dd442348bc116f2d35b17f0a",
+                "sha256:758e691dbb454d5ccf4e1b154a19e52847f79e21a42fef17b969144af29a4e6c"
             ],
             "index": "pypi",
-            "version": "==2.3.0"
+            "version": "==2.4.0"
         },
         "ecs-logging": {
             "hashes": [
@@ -377,6 +389,14 @@
             ],
             "index": "pypi",
             "version": "==7.4.1"
+        },
+        "exceptiongroup": {
+            "hashes": [
+                "sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5",
+                "sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f"
+            ],
+            "markers": "python_version < '3.11'",
+            "version": "==1.1.2"
         },
         "flask": {
             "hashes": [
@@ -434,61 +454,40 @@
         },
         "gevent": {
             "hashes": [
-                "sha256:018f93de7d5318d2fb440f846839a4464738468c3476d5c9cf7da45bb71c18bd",
-                "sha256:0d581f22a5be6281b11ad6309b38b18f0638cf896931223cbaa5adb904826ef6",
-                "sha256:1472012493ca1fac103f700d309cb6ef7964dcdb9c788d1768266e77712f5e49",
-                "sha256:172caa66273315f283e90a315921902cb6549762bdcb0587fd60cb712a9d6263",
-                "sha256:17b68f4c9e20e47ad49fe797f37f91d5bbeace8765ce2707f979a8d4ec197e4d",
-                "sha256:1ca01da176ee37b3527a2702f7d40dbc9ffb8cfc7be5a03bfa4f9eec45e55c46",
-                "sha256:1d543c9407a1e4bca11a8932916988cfb16de00366de5bf7bc9e7a3f61e60b18",
-                "sha256:1e1286a76f15b5e15f1e898731d50529e249529095a032453f2c101af3fde71c",
-                "sha256:1e955238f59b2947631c9782a713280dd75884e40e455313b5b6bbc20b92ff73",
-                "sha256:1f001cac0ba8da76abfeb392a3057f81fab3d67cc916c7df8ea977a44a2cc989",
-                "sha256:1ff3796692dff50fec2f381b9152438b221335f557c4f9b811f7ded51b7a25a1",
-                "sha256:2929377c8ebfb6f4d868d161cd8de2ea6b9f6c7a5fcd4f78bcd537319c16190b",
-                "sha256:319d8b1699b7b8134de66d656cd739b308ab9c45ace14d60ae44de7775b456c9",
-                "sha256:323b207b281ba0405fea042067fa1a61662e5ac0d574ede4ebbda03efd20c350",
-                "sha256:3b7eae8a0653ba95a224faaddf629a913ace408edb67384d3117acf42d7dcf89",
-                "sha256:4114f0f439f0b547bb6f1d474fee99ddb46736944ad2207cef3771828f6aa358",
-                "sha256:4197d423e198265eef39a0dea286ef389da9148e070310f34455ecee8172c391",
-                "sha256:494c7f29e94df9a1c3157d67bb7edfa32a46eed786e04d9ee68d39f375e30001",
-                "sha256:4e2f008c82dc54ec94f4de12ca6feea60e419babb48ec145456907ae61625aa4",
-                "sha256:53ee7f170ed42c7561fe8aff5d381dc9a4124694e70580d0c02fba6aafc0ea37",
-                "sha256:54f4bfd74c178351a4a05c5c7df6f8a0a279ff6f392b57608ce0e83c768207f9",
-                "sha256:58898dbabb5b11e4d0192aae165ad286dc6742c543e1be9d30dc82753547c508",
-                "sha256:59b47e81b399d49a5622f0f503c59f1ce57b7705306ea0196818951dfc2f36c8",
-                "sha256:5aa99e4882a9e909b4756ee799c6fa0f79eb0542779fad4cc60efa23ec1b2aa8",
-                "sha256:6c04ee32c11e9fcee47c1b431834878dc987a7a2cc4fe126ddcae3bad723ce89",
-                "sha256:84c517e33ed604fa06b7d756dc0171169cc12f7fdd68eb7b17708a62eebf4516",
-                "sha256:8729129edef2637a8084258cb9ec4e4d5ca45d97ac77aa7a6ff19ccb530ab731",
-                "sha256:877abdb3a669576b1d51ce6a49b7260b2a96f6b2424eb93287e779a3219d20ba",
-                "sha256:8c192d2073e558e241f0b592c1e2b34127a4481a5be240cad4796533b88b1a98",
-                "sha256:8f2477e7b0a903a01485c55bacf2089110e5f767014967ba4b287ff390ae2638",
-                "sha256:96c56c280e3c43cfd075efd10b250350ed5ffd3c1514ec99a080b1b92d7c8374",
-                "sha256:97cd42382421779f5d82ec5007199e8a84aa288114975429e4fd0a98f2290f10",
-                "sha256:98bc510e80f45486ef5b806a1c305e0e89f0430688c14984b0dbdec03331f48b",
-                "sha256:990d7069f14dc40674e0d5cb43c68fd3bad8337048613b9bb94a0c4180ffc176",
-                "sha256:9d85574eb729f981fea9a78998725a06292d90a3ed50ddca74530c3148c0be41",
-                "sha256:a2237451c721a0f874ef89dbb4af4fdc172b76a964befaa69deb15b8fff10f49",
-                "sha256:a47a4e77e2bc668856aad92a0b8de7ee10768258d93cd03968e6c7ba2e832f76",
-                "sha256:a5488eba6a568b4d23c072113da4fc0feb1b5f5ede7381656dc913e0d82204e2",
-                "sha256:ae90226074a6089371a95f20288431cd4b3f6b0b096856afd862e4ac9510cddd",
-                "sha256:b43d500d7d3c0e03070dee813335bb5315215aa1cf6a04c61093dfdd718640b3",
-                "sha256:b6c144e08dfad4106effc043a026e5d0c0eff6ad031904c70bf5090c63f3a6a7",
-                "sha256:d21ad79cca234cdbfa249e727500b0ddcbc7adfff6614a96e6eaa49faca3e4f2",
-                "sha256:d82081656a5b9a94d37c718c8646c757e1617e389cdc533ea5e6a6f0b8b78545",
-                "sha256:da4183f0b9d9a1e25e1758099220d32c51cc2c6340ee0dea3fd236b2b37598e4",
-                "sha256:db562a8519838bddad0c439a2b12246bab539dd50e299ea7ff3644274a33b6a5",
-                "sha256:ddaa3e310a8f1a45b5c42cf50b54c31003a3028e7d4e085059090ea0e7a5fddd",
-                "sha256:ed7f16613eebf892a6a744d7a4a8f345bc6f066a0ff3b413e2479f9c0a180193",
-                "sha256:efc003b6c1481165af61f0aeac248e0a9ac8d880bb3acbe469b448674b2d5281",
-                "sha256:f01c9adbcb605364694b11dcd0542ec468a29ac7aba2fb5665dc6caf17ba4d7e",
-                "sha256:f23d0997149a816a2a9045af29c66f67f405a221745b34cefeac5769ed451db8",
-                "sha256:f3329bedbba4d3146ae58c667e0f9ac1e6f1e1e6340c7593976cdc60aa7d1a47",
-                "sha256:f7ed2346eb9dc4344f9cb0d7963ce5b74fe16fdd031a2809bb6c2b6eba7ebcd5"
+                "sha256:11b9bb0bce45170ff992760385a86e6955ccb88dba4a82a64d5ce9459290d8d6",
+                "sha256:1234849b0bc4df560924aa92f7c01ca3f310677735fb508a2b0d7a61bb946916",
+                "sha256:34086bcc1252ae41e1cb81cf13c4a7678031595c12f4e9a1c3d0ab433f20826a",
+                "sha256:369241d1a6a3fe3ef4eba454b71e0168026560c5344fc4bc37196867041982ac",
+                "sha256:3e0d76a7848726e0646324a1adc011355dcd91875e7913badd1ada2e5eeb8a6e",
+                "sha256:5b230007a665d2cf5cf8878c9f56a2b8bacbdc4fe0235afc5269b71cd00528e5",
+                "sha256:5da07d65dfa23fe419c37cea110bf951b42af6bf3a1fff244043a75c9185dbd5",
+                "sha256:6a51a8e3cdaa6901e47d56f84cb5f92b1bf3deea920bce69cf7a245df16159ac",
+                "sha256:6b3dd449c80814357f6568eb095a2be2421b805d59fa97c65094707e04a181f9",
+                "sha256:6bd9ea1b5fbdc7e5921a9e515f34a450eb3927a902253a33caedcce2d19d7d96",
+                "sha256:746a1e12f280dab07389e6709164b1e1a6caaf50493ea5b1dcaa73cff005174c",
+                "sha256:769e8811ded08fe7d8b09ad8ebb72d47aecc112411e0726e7296b7ed187ed629",
+                "sha256:76ca6f893953ab898ebbff5d772103318a85044e55d0bad401d6b49d71bb76e7",
+                "sha256:83b6d61a8e9da25edb304ca7fba19ee57bb1ffa801f9df3e668bfed7bb8386cb",
+                "sha256:8c284390f0f6d0b5be3bf805fa8e0ae1329065f2b0ac5af5423c67183197deb8",
+                "sha256:919423e803939726c99ab2d29ea46b8676af549cee72d263f2b24758ec607b2c",
+                "sha256:94b013587f7c4697d620c129627f7b12d7d9f6e40ab198635891ca2098cd8556",
+                "sha256:9c7c349aa23d67cf5cc3b2c87aaedcfead976d0577b1cfcd07ffeba63baba79c",
+                "sha256:a1d2f1e67d04fde47ca2deac89733df28ef3a7ec1d7359a79f57d4778cced16d",
+                "sha256:a226b42cb9a49580ca7729572a4f8289d1fa28cd2529c9f4eed3e14b995d1c9c",
+                "sha256:a8f62e8d37913512823923e05607a296389aeb50ccca8a271ae7cedb5b17faeb",
+                "sha256:add904a7ef960cd4e133e61eb7413982c5e4203928160be1c09752ac06a25e71",
+                "sha256:aeb1511cf0786152af741c47ee462dac81b57bbd1fbbe08ab562b6c8c9ad75ed",
+                "sha256:c1dba07207b15b371e50372369edf256a142cb5cdf8599849cbf8660327efa06",
+                "sha256:c92b837b60e850c50fc6d723d1e363e786d37fd9d51e564e07df52ad5e8a86d4",
+                "sha256:cea93f4f77badbddc711620cca164ad75c74056603908e621a5ba1b97adbc39c",
+                "sha256:d0d3630674c1b344b256a298ab1ff43220f840b12af768131b5d74e485924237",
+                "sha256:debc177e88a8c876cb1a4d974f985d03670177bdc61e1c084a8d525f1a50b12d",
+                "sha256:dec7b08daf08385fb281b81ec2e7e703243975d867f40ae0a8a3e30b380eb9ea",
+                "sha256:df4d7be3352126458cc818309ca6a3b678c209b1ae33e56b6975c6a8309f2068",
+                "sha256:f522b6b015f1bfa9d8d3716ddffb23e3d4a8933df3e4ebf0a29a65a9fa74382b"
             ],
             "index": "pypi",
-            "version": "==22.10.2"
+            "version": "==23.7.0"
         },
         "greenlet": {
             "hashes": [
@@ -553,7 +552,7 @@
                 "sha256:f82d4d717d8ef19188687aa32b8363e96062911e63ba22a0cff7802a8e58e5f1",
                 "sha256:fc3a569657468b6f3fb60587e48356fe512c1754ca05a564f11366ac9e306526"
             ],
-            "markers": "platform_python_implementation == 'CPython'",
+            "markers": "python_version < '3.12' and platform_python_implementation == 'CPython'",
             "version": "==2.0.2"
         },
         "gunicorn": {
@@ -563,6 +562,22 @@
             ],
             "index": "pypi",
             "version": "==20.1.0"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d",
+                "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.14.0"
+        },
+        "httpcore": {
+            "hashes": [
+                "sha256:a6f30213335e34c1ade7be6ec7c47f19f50c56db36abef1a9dfa3815b1cb3888",
+                "sha256:c2789b767ddddfa2a5782e3199b2b7f6894540b17b16ec26b2c4d8e103510b87"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.17.3"
         },
         "idna": {
             "hashes": [
@@ -574,19 +589,19 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4",
-                "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"
+                "sha256:3ebb78df84a805d7698245025b975d9d67053cd94c79245ba4b3eb694abe68bb",
+                "sha256:dbace7892d8c0c4ac1ad096662232f831d4e64f4c4545bd53016a3e9d4654743"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==6.7.0"
+            "version": "==6.8.0"
         },
         "importlib-resources": {
             "hashes": [
-                "sha256:4be82589bf5c1d7999aedf2a45159d10cb3ca4f19b2271f8792bc8e6da7b22f6",
-                "sha256:7b1deeebbf351c7578e09bf2f63fa2ce8b5ffec296e0d349139d43cca061a81a"
+                "sha256:4cf94875a8368bd89531a756df9a9ebe1f150e0f885030b461237bc7f2d905f2",
+                "sha256:d952faee11004c045f785bb5636e8f885bed30dc3c940d5d42798a2a4541c185"
             ],
             "markers": "python_version < '3.9'",
-            "version": "==5.12.0"
+            "version": "==6.0.0"
         },
         "iso8601": {
             "hashes": [
@@ -613,11 +628,11 @@
         },
         "jsonschema": {
             "hashes": [
-                "sha256:8caf5b57a990a98e9b39832ef3cb35c176fe331414252b6e1b26fd5866f891a4",
-                "sha256:b508dd6142bd03f4c3670534c80af68cd7bbff9ea830b9cf2625d4a3c49ddf60"
+                "sha256:64b7104d72efe856bea49ca4af37a14a9eba31b40bb7238179f3803130fd34d9",
+                "sha256:aab78b34c2de001c6b692232f08c21a97b436fe18e0b817bf0511046924fceef"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==4.18.0"
+            "version": "==4.18.3"
         },
         "jsonschema-specifications": {
             "hashes": [
@@ -637,6 +652,7 @@
         },
         "lxml": {
             "hashes": [
+                "sha256:05186a0f1346ae12553d66df1cfce6f251589fea3ad3da4f3ef4e34b2d58c6a3",
                 "sha256:075b731ddd9e7f68ad24c635374211376aa05a281673ede86cbe1d1b3455279d",
                 "sha256:081d32421db5df44c41b7f08a334a090a545c54ba977e47fd7cc2deece78809a",
                 "sha256:0a3d3487f07c1d7f150894c238299934a2a074ef590b583103a45002035be120",
@@ -645,6 +661,7 @@
                 "sha256:0e2cb47860da1f7e9a5256254b74ae331687b9672dfa780eed355c4c9c3dbd23",
                 "sha256:120fa9349a24c7043854c53cae8cec227e1f79195a7493e09e0c12e29f918e52",
                 "sha256:1247694b26342a7bf47c02e513d32225ededd18045264d40758abeb3c838a51f",
+                "sha256:141f1d1a9b663c679dc524af3ea1773e618907e96075262726c7612c02b149a4",
                 "sha256:14e019fd83b831b2e61baed40cab76222139926b1fb5ed0e79225bc0cae14584",
                 "sha256:1509dd12b773c02acd154582088820893109f6ca27ef7291b003d0e81666109f",
                 "sha256:17a753023436a18e27dd7769e798ce302963c236bc4114ceee5b25c18c52c693",
@@ -652,6 +669,7 @@
                 "sha256:1f447ea5429b54f9582d4b955f5f1985f278ce5cf169f72eea8afd9502973dd5",
                 "sha256:23eed6d7b1a3336ad92d8e39d4bfe09073c31bfe502f20ca5116b2a334f8ec02",
                 "sha256:25f32acefac14ef7bd53e4218fe93b804ef6f6b92ffdb4322bb6d49d94cad2bc",
+                "sha256:2c74524e179f2ad6d2a4f7caf70e2d96639c0954c943ad601a9e146c76408ed7",
                 "sha256:303bf1edce6ced16bf67a18a1cf8339d0db79577eec5d9a6d4a80f0fb10aa2da",
                 "sha256:3331bece23c9ee066e0fb3f96c61322b9e0f54d775fccefff4c38ca488de283a",
                 "sha256:3e9bdd30efde2b9ccfa9cb5768ba04fe71b018a25ea093379c857c9dad262c40",
@@ -665,7 +683,9 @@
                 "sha256:4c28a9144688aef80d6ea666c809b4b0e50010a2aca784c97f5e6bf143d9f129",
                 "sha256:4d2d1edbca80b510443f51afd8496be95529db04a509bc8faee49c7b0fb6d2cc",
                 "sha256:4dd9a263e845a72eacb60d12401e37c616438ea2e5442885f65082c276dfb2b2",
+                "sha256:4f1026bc732b6a7f96369f7bfe1a4f2290fb34dce00d8644bc3036fb351a4ca1",
                 "sha256:4fb960a632a49f2f089d522f70496640fdf1218f1243889da3822e0a9f5f3ba7",
+                "sha256:50670615eaf97227d5dc60de2dc99fb134a7130d310d783314e7724bf163f75d",
                 "sha256:50baa9c1c47efcaef189f31e3d00d697c6d4afda5c3cde0302d063492ff9b477",
                 "sha256:53ace1c1fd5a74ef662f844a0413446c0629d151055340e9893da958a374f70d",
                 "sha256:5515edd2a6d1a5a70bfcdee23b42ec33425e405c5b351478ab7dc9347228f96e",
@@ -682,6 +702,7 @@
                 "sha256:6fc3c450eaa0b56f815c7b62f2b7fba7266c4779adcf1cece9e6deb1de7305ce",
                 "sha256:704f61ba8c1283c71b16135caf697557f5ecf3e74d9e453233e4771d68a1f42d",
                 "sha256:71c52db65e4b56b8ddc5bb89fb2e66c558ed9d1a74a45ceb7dcb20c191c3df2f",
+                "sha256:71d66ee82e7417828af6ecd7db817913cb0cf9d4e61aa0ac1fde0583d84358db",
                 "sha256:7d298a1bd60c067ea75d9f684f5f3992c9d6766fadbc0bcedd39750bf344c2f4",
                 "sha256:8b77946fd508cbf0fccd8e400a7f71d4ac0e1595812e66025bac475a8e811694",
                 "sha256:8d7e43bd40f65f7d97ad8ef5c9b1778943d02f04febef12def25f7583d19baac",
@@ -690,10 +711,12 @@
                 "sha256:92af161ecbdb2883c4593d5ed4815ea71b31fafd7fd05789b23100d081ecac96",
                 "sha256:97047f0d25cd4bcae81f9ec9dc290ca3e15927c192df17331b53bebe0e3ff96d",
                 "sha256:9719fe17307a9e814580af1f5c6e05ca593b12fb7e44fe62450a5384dbf61b4b",
+                "sha256:9767e79108424fb6c3edf8f81e6730666a50feb01a328f4a016464a5893f835a",
                 "sha256:9a92d3faef50658dd2c5470af249985782bf754c4e18e15afb67d3ab06233f13",
                 "sha256:9bb6ad405121241e99a86efff22d3ef469024ce22875a7ae045896ad23ba2340",
                 "sha256:9e28c51fa0ce5674be9f560c6761c1b441631901993f76700b1b30ca6c8378d6",
                 "sha256:aca086dc5f9ef98c512bac8efea4483eb84abbf926eaeedf7b91479feb092458",
+                "sha256:ae8b9c6deb1e634ba4f1930eb67ef6e6bf6a44b6eb5ad605642b2d6d5ed9ce3c",
                 "sha256:b0a545b46b526d418eb91754565ba5b63b1c0b12f9bd2f808c852d9b4b2f9b5c",
                 "sha256:b4e4bc18382088514ebde9328da057775055940a1f2e18f6ad2d78aa0f3ec5b9",
                 "sha256:b6420a005548ad52154c8ceab4a1290ff78d757f9e5cbc68f8c77089acd3c432",
@@ -711,16 +734,27 @@
                 "sha256:d3ff32724f98fbbbfa9f49d82852b159e9784d6094983d9a8b7f2ddaebb063d4",
                 "sha256:d73d8ecf8ecf10a3bd007f2192725a34bd62898e8da27eb9d32a58084f93962b",
                 "sha256:dd708cf4ee4408cf46a48b108fb9427bfa00b9b85812a9262b5c668af2533ea5",
+                "sha256:e3cd95e10c2610c360154afdc2f1480aea394f4a4f1ea0a5eacce49640c9b190",
+                "sha256:e4da8ca0c0c0aea88fd46be8e44bd49716772358d648cce45fe387f7b92374a7",
                 "sha256:eadfbbbfb41b44034a4c757fd5d70baccd43296fb894dba0295606a7cf3124aa",
                 "sha256:ed667f49b11360951e201453fc3967344d0d0263aa415e1619e85ae7fd17b4e0",
                 "sha256:f3df3db1d336b9356dd3112eae5f5c2b8b377f3bc826848567f10bfddfee77e9",
                 "sha256:f6bdac493b949141b733c5345b6ba8f87a226029cbabc7e9e121a413e49441e0",
+                "sha256:fbf521479bcac1e25a663df882c46a641a9bff6b56dc8b0fafaebd2f66fb231b",
                 "sha256:fc9b106a1bf918db68619fdcd6d5ad4f972fdd19c01d19bdb6bf63f3589a9ec5",
                 "sha256:fcdd00edfd0a3001e0181eab3e63bd5c74ad3e67152c84f93f13769a40e073a7",
                 "sha256:fe4bda6bd4340caa6e5cf95e73f8fea5c4bfc55763dd42f1b50a94c1b4a2fbd4"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==4.9.3"
+        },
+        "markdown": {
+            "hashes": [
+                "sha256:065fd4df22da73a625f14890dd77eb8040edcbd68794bcd35943be14490608b2",
+                "sha256:8bf101198e004dc93e84a12a7395e31aac6a9c9942848ae1d99b9d72cf9b3520"
+            ],
+            "index": "pypi",
+            "version": "==3.4.3"
         },
         "markupsafe": {
             "hashes": [
@@ -1078,84 +1112,106 @@
         },
         "rpds-py": {
             "hashes": [
-                "sha256:0c62fdb01111da948e8446caaefebf2ca4307a58fcbc10039b48d0db7205397c",
-                "sha256:0df2ae878fd99342415a42659f3bcee34b12441a509033e0ab04c6e301895607",
-                "sha256:0dfec14a64759186153115d987f9e60b1fa7e8e14a00004a02482e696199e554",
-                "sha256:0e8da63b9baa154ec9ddd6dd397893830d17e5812ceb50edbae8122d8ecb9f2e",
-                "sha256:13aed64f2e0bef04a0eae6d1d1295f901f6c1640d1e20264dc3b19d62ef1721d",
-                "sha256:180963bb3e1fcc6ed6313ece5e065f0df4021a7eb7016084d3cbc90cd2a8af3e",
-                "sha256:1891903e567d728175c0475a1f0ffc1d1580013b0b265b9e2f1b8c93d58b2d05",
-                "sha256:18a97bb7f211b247346983092186927c517153ac155c611f43ca83d5ee93a3e2",
-                "sha256:1f60a7eb96fedcc5bf59761d33ac0f2f127d75f8c4b99ed0f138fc0f3601c537",
-                "sha256:22afed13c6ad4ccdc650ad44cbc06f835f4f30de201bd4ee2afc09bde06a357a",
-                "sha256:246a410e540ce7f635c6ad1b7aa00b7dcfc966c5f97217e41092c3f764dac4bf",
-                "sha256:247a1fd9bcdb373380cb8c0041417c9995fc163c9d88a39f5ec3d960114aca22",
-                "sha256:25a4b357ba7540d7cc709915699d67d505c8177cdb30824127092e1b4886b504",
-                "sha256:2d6a26953d3b291dd7e79e43bb203ed134ca889e63c8ebbc65e3ff98154303ef",
-                "sha256:300b8579740b06e246238b730e636f314a7d8dc475be1868650f5d3ddc29a0d8",
-                "sha256:316a66b0379a9e954872593aa2eb6d61949da2ecc8f572b4dafb07aa0e247171",
-                "sha256:358c7a976482537d26fcbdc7808e7cc25f64816fe89681f9aa8bef13e16c7370",
-                "sha256:36266e2e49b36ec6cc148e36667030d8e7f1c009edd2ca978ab09ed9c5a7589a",
-                "sha256:3660bd2afb23e1ca685df0d3092208fe6c7b2cae8c0be199b3da6d1a4bc91dc5",
-                "sha256:42eb3030665ee7a5c03fd4db6b8db1983aa91bcdffbed0f4687751deb2a94a7c",
-                "sha256:4333b5c2801e44bf342207a7700378a1013f300116c9553ce1ffbc73047d2a02",
-                "sha256:4b5164fdad37847e90683d3748dca7c4604f47ecd21e2d651dafc80393d1d314",
-                "sha256:4c66a5f9ca9c5fcb2527ad969541521f7216db713a7bd63aee52c3f5efa5924a",
-                "sha256:5b7c87503843a036f898d44c47326a117d23b6269a9f1574adf83d7bb051b839",
-                "sha256:657348b35a4c2e7c2340bf0bc37597900037bd87e9db7e6282711aaa77256e16",
-                "sha256:681ef7a21e6990583533c3a3038b7176f5e51e5d345fe2d9109b54f6bffcabcd",
-                "sha256:6b1b235b890373f785507f8f6a644a4f191b7195939e7f6108dc0e5e4fab57fd",
-                "sha256:6e85ea159f2d2132d4fcb71abb7df9683314f6073bf8ee9f9bd576440245e59c",
-                "sha256:6ee396f63a1f540fb3aecb8cc698180d30573a661be47fb3fff45cbd2b5d4686",
-                "sha256:7110854662ccf8db84b90e4624301ef5311cafff7e5f2a63f2d7cc0fc1a75b60",
-                "sha256:755a837fb7053dbf511fba26343423bd80d3b75a5d7f57f6e407c2fe5ae46682",
-                "sha256:7628b2080538faa4a1243b0002678cae7111af68ae7b5aa6cd8526762cace868",
-                "sha256:78c5577f99d2edc9eed9ec39fae27b73d04d1b2462aff6f6b11207e0364fc40d",
-                "sha256:79ac819182795a2168ed11075c7362de368f360244fb7cea8274c222b2d55365",
-                "sha256:7bd8dbc1c63668124e5e48e601d32f1053cfd5a86004ae0e55dc9ba8b1e7de29",
-                "sha256:87d74c2526115daa9d805a66377997602185a837ff7ecceed9d27e625c383572",
-                "sha256:8ac1e47ee4cb2dbd714537e63c67086eec63f56b13208fe450ae5be4f3d65671",
-                "sha256:8e1251d6690f356a305192089017da83999cded1d7e2405660d14c1dff976af7",
-                "sha256:8f64ef5700ff8fded62b12d1ea55463031cc5a353b670ed7146126c6cbf28788",
-                "sha256:961828c668140796c4963edb14cd968666d5414b9b5829997a4f475fd917906e",
-                "sha256:9af40bb89e40932e04c0cc1fb516249d6b3ae68ceebd984fdc592a6673244e50",
-                "sha256:9b331fa451d725258c1ad0ae6816cf36d55294e5cb68338cf91550b9a448a48f",
-                "sha256:a747477838a90b9264f434b5399309f9badb32c80ff3e9c4f6d5b87fddcbaa09",
-                "sha256:ac596301c7723809ecb6ec4cb2564b2cadc06f8c07b6348a56fcbf1ae043d751",
-                "sha256:b189640d59afa8aeff59865fa9d314bca97987c378950f215297e15d64ae1124",
-                "sha256:b3ed0d3498b69159db0d5db1393c8bae4df51cf936b2ef5cda53d800acab0019",
-                "sha256:b5a55fd01f61df19e4f53fd67b63ca9bf47559632c3f7d4037faa06d3a6fed54",
-                "sha256:b5cbcbd6451a4af2048fc0b21c15981462f6a378cb039aa53612c6e39958064e",
-                "sha256:b949e86affe17c8828d82936c51d7aa9b686511f9ac99a4b1de596d7140c8083",
-                "sha256:bfe98ad05400e7ac7a1df791645db08c66adc92d7a6449a406111303a265b71a",
-                "sha256:c0fe018430e5e8e1d8b513bcbccdb0ea34b9fd81c32b3a49c41a109fade17cfb",
-                "sha256:c26b1a0425c038cc23cf5770a47d7a7382fe68d6d10fb2a52c2896ca94e72550",
-                "sha256:c7019b2522af6b835118177b6b53f7ed08da28061aa5d44e06286be09799e7a4",
-                "sha256:c97e4cbe722474d17c309ee49e09331ceffe345bb72e2b10c6c740788871b122",
-                "sha256:cafbfa8f3a27e592bdcc420497e0c9a957c9f812b6c6ebfb7f961409215ba82d",
-                "sha256:cea42c2f52e37877e6b877bce64d109a6b0213e32545ecc70d4492d2a4641b8f",
-                "sha256:d2f8666fde7cfd9cdbc6c223876b39697d387f0215d12ed25147e9efec2dff5a",
-                "sha256:d418d2fd8c0fffe2897bc3e15a2e2ec87abf29076f0c36898cc33fb7881c2cbe",
-                "sha256:d4334405f6c73c29ff94521f78ad53ebb76a9c1b8dafea75852f9f64c3679cf7",
-                "sha256:d6696c2a002e982e89975063939a2579623d6d6b24634b147848ec9f35dad7d6",
-                "sha256:d7e46f52272ceecc42c05ad869b068b2dbfb6eb5643bcccecd2327d3cded5a2e",
-                "sha256:db71c665fc7ddb9ac53d7b69dc588493c0b71635b28fc8ff64b31eb9db5b3461",
-                "sha256:ddb5226b11f4fce98c6e47c07819fbbfdda6d3fd529cd176ad8a1e0b98a70b05",
-                "sha256:df3097abf5fd09bfcd8f6fd02d052b25cc3e160b3ee71b6fbd831b2cd516c958",
-                "sha256:e086610118163400a1822af0ee857581c0e047aa50a9c3543d17fbe65183a339",
-                "sha256:e1700fba17dd63c9c7d5cb03cf838db23cf938dd5cdb1eecb6ba8b8da62c3e73",
-                "sha256:e261fa453ad50fe1d9287fa21d962cdbcd3d495cf1160dd0f893883040c455b6",
-                "sha256:e4e11f71673905d9e8735b8dd4ef8fa85a82e6003851fe46f9bdc51aebc2cd5d",
-                "sha256:ea8c4a1232c7bacf73366b0490dda7f67d25958aec1c2f099b6753c8bfe84427",
-                "sha256:ed823997c3300b541da0fcc9eee8fbe6740e07939ffa432824cfca287472d652",
-                "sha256:ee42ce4ef46ea334ce8ab63d5a57c7fd78238c9c7293b3caa6dfedf11bd28773",
-                "sha256:f1c84912d77b01651488bbe392df593b4c5852e213477e268ebbb7c799059d78",
-                "sha256:f81a570a20f9fce617d728f4e3bdc05bfbb68afa2e795ec0c52544a7923de517",
-                "sha256:f8a1cc37e2395002381510a6862c29634acd67edfe5774661a6c48d8617acae7",
-                "sha256:fffd98c1fd6b38df35e471549c2486d826af0fda6ca55c0bbbb956b291e7f2ae"
+                "sha256:018b2820e01fe1bbcfb7ecb9d8e42beda2d5e8c68dddb8331085c069496ee7b4",
+                "sha256:05d7fba86f453e68e8c08b1db6c7462fff8f4773e190b11a2b841b090abf67ff",
+                "sha256:07a485449b0f4819a6aaa6d8e290841239eed2fff1e3065a45a437da597bdb14",
+                "sha256:07a87f9d4be317d567422553f3a5b54bb068f5c28e7271e04914c011c373b5f6",
+                "sha256:0af4dad7ffaa29ca1fd048b667a1b3db46ce1353f01d606b3d03d18649adab5a",
+                "sha256:0ea0c01d22aae66b4fd3e3ead0abbe6a6bace032441c281687906ab723e7b00a",
+                "sha256:0ee7d4acb2cb1ccda55db9cf2087b7ed3f38175228feddd63a3c334c786e8248",
+                "sha256:18667ccf333fc615a63203be08262ce58c2bdf135c9c2fa245556f5d20d14028",
+                "sha256:1906f35d7becb01b10b1feb0906a7c5d4634dc70ba2ef92e664c6001658d36f0",
+                "sha256:1a49829d460f6b089c245de3e69b2b22c5ec783e53e70a4116b8cc3cf490047c",
+                "sha256:1af977101487862222be5f526cd9921a2070805acedc9b46cf4268d5dc8a915b",
+                "sha256:1b5546bc4c2c0c0d71859f6db1f150634d481252b40842157aff5a082a5dd999",
+                "sha256:1b56e340ef68f12566e4094df317b1afc62e93db236916a2c653c1ace0c06d50",
+                "sha256:26da604ae094924ad522a083d90cf030c9578a1b9611cdecd19d689a645d042d",
+                "sha256:2708cb3df058446c9aaee8213ad472cbf6be798fa05baf81e2b1b0b67abadfa2",
+                "sha256:2a7eb90d7df5a1a268cef733d2798dca39cf63dfb2d296356cd0e938e6c2090d",
+                "sha256:2ee70fa6b3151e0da19185802e8bacddc8b24d6bdac5e1c85072acae19ec734a",
+                "sha256:3104cd647da83001d608165e0dc0b5747ce8ea12c96d6b83fb2c43fa68135018",
+                "sha256:33169a32e8996086f5270de1b51c8fc699aefd5d7a0288f747c7ffd72acc6c83",
+                "sha256:364f70d9802ef628c13a04a6636e0bbe7f1a58c2560955da17c7117ed1ee8762",
+                "sha256:38208701e09e77c1158b1538c687c5b0a6a894a689bbd1f6eafc5cd31a7cd59d",
+                "sha256:3d1830d31db000bec0599665349e026614676432c87aeef98cac970254d4e36f",
+                "sha256:3ff2b6d317eea667260c7265977575f49116781e4fcc4973360b84aec24644e3",
+                "sha256:4017d2920e8e3f936e6fc3b65e60a655c690c472901f0ff1a8f62ee21c493f19",
+                "sha256:41b8c08eef01d6183a942567e2069966d53b826abdd3076e4cabd02cf158b338",
+                "sha256:43745fcd13243ba67a4617bfede75bc81c2e990cfac7581b4aa8b7f43ac16b80",
+                "sha256:444ea661de45cf0334131904d717254462d8c974d551caac795f4232920bdb47",
+                "sha256:45cb51ac40c48cdcaaf873a7a7cb9231e3a3f561c5cc4af6e8ab43bf7601c02a",
+                "sha256:47aba4c789842d9e408162d483ba9fa7f681fa996607e935cbdcb3b23b16dab9",
+                "sha256:4907793f6186df1ed20a828d8315bfd25376924b92bc8bf7ae27548e498bd567",
+                "sha256:4a7b21de1684a2ebbeb2fbd9b03495a9d7787305e46c6ec42c6340fc647e37d5",
+                "sha256:4b40fc5904e8053ac9e4f5b0e9af949bc276098f14a46e992ab072a3d706675a",
+                "sha256:4e1a12c4a2dc42c74981b39f35ebf8372dc78281ea7d5ded9ef91ed3e6501bce",
+                "sha256:53467e07da630e31bcbe741616b2a006c11236e63688ad69324b8f71bf035b8b",
+                "sha256:59a3407643acbcf697309b3b7d346f59d9ba4527a2a02a4fc1417766a2e2af8a",
+                "sha256:5b3ffee8a0f48cfb6670533463efd0aa529833bfb747e6c7077229e1a253a7c1",
+                "sha256:6616eaa330fc925f15bc796efefeb45fb262213422d1274656d062359cf707c0",
+                "sha256:67768f54ee4ff5c6811d505d14d22bc5e98b04743a12ee79637e06caec4cc7db",
+                "sha256:6d59b7f535c6e9ce10fbdb09e31589fa5aba19e867275578087bd1a243b47b56",
+                "sha256:71e47154e72eadd210b204c696b6ab65fd685ea08aabb6e434dc8060220168f3",
+                "sha256:760b994c3ddc68e6c5e750484e4c6a687e5b1c2f73d791834feb1ca6a9efc79c",
+                "sha256:82a9ff8ec847ffba78087dfcc42e78869d7c19f89f91e838d2ad35e70b00a51f",
+                "sha256:888f166b3feb1a19a1d616fe799ad648d1be85586cb49480e4b65c3f6b217d5a",
+                "sha256:8a40d5a10a7a6ae5c379f9ac099f55eab9dac4dcfed79b34df37ad84137dc6a7",
+                "sha256:8b3b0ff70afe08d5e7a719e69bc48ae4643fa7301cdab642bddbdf014190b651",
+                "sha256:8c755419ba9fbcd87a62837b6388456b3684c5efc41df03ac3f4c42229e84459",
+                "sha256:8d9b1a38b5f1346c19b6fc5595998435b0327426a6f54597653eb4fe24f737c6",
+                "sha256:8e0207dc216dc04b70781c84ddaa198caff01ced30307340cc5878f69ef4bb72",
+                "sha256:946c98e168fe2c54335915ed1d82a162257d9943e84af1e8ddc741bdfba78c23",
+                "sha256:948ab99c751149a612a3b432d400d5f26819589598eab75e083c3e98858f13b0",
+                "sha256:96349901b73c0f21e9eee04b0422ca122772d9b7e71afe0535ce464c0fa046cf",
+                "sha256:96628ba384dc07af9df51d8ee0828ed0118b9229d9a78c1b70198313ec621033",
+                "sha256:96d247ea2a18e2307e3fd0b3860e1bca847df534d7f4cd2fc3525eaa10c71571",
+                "sha256:99a586d7dbad835352d6c3b6c4ae56c9fdffda800c74d2986513a2c514a35c6c",
+                "sha256:9c42d44ed2fdf14b5ba3fc1461bc124031de59ee2750642205a55820f81c17ea",
+                "sha256:9ec03f7f2c62fd7c8516448ded95c022d83b802a847e1d5c5da30b602f481f5e",
+                "sha256:a1cdb85c001a021634ea326c095cc2cf08a287ae55ad1e9376be5ff6e9ab7e30",
+                "sha256:a51d5a83213c05fb975dbdedd4406c165c7657eabe92cb1f9441e881bfd17874",
+                "sha256:a5acc515aef399ddcfb59d1e6414f8ae9fc559d8068319cad6e4154d2348ea68",
+                "sha256:a77de26a65ec87b2ec981b9fc50527e43238f0cc840fec3a8ba9789112a77cad",
+                "sha256:aa01d4c2bfb7b6f78d0ac7e5796cdc7dcd93cb74d0f6eefa14f0ce15ffdc287c",
+                "sha256:aa9308649feff2acf29057fbc7bc26cfd0482b80060375e12fe2dfae4a6c2eb8",
+                "sha256:acdd9d5f39e12a6519a38609a144ccee67d24a9991f21c64d4f92806503a3e1a",
+                "sha256:ae19845478ed4f307560b72608e723b5ea1702cb87c1c1479e372d1787203dda",
+                "sha256:af1a820a8046bad8e326db5a829057b2eb601127ee33360056158ef7c437460b",
+                "sha256:b27d5267d92b2741d4864a463ad9f1c941aa44b6f8dce420bc620946169a1cac",
+                "sha256:b47fa4aa6cb0a7e0a09822e7f362a14afd9786d030e8485b92aa10ad13732e34",
+                "sha256:b9ece08b4a0df42002ebf9f23e521c74ec924f3d1542254056efc271fe611b91",
+                "sha256:bb02e326d3e925d2f22c7ea6db495b59cf81b8e0f9f841d72bc0eab7be59a08c",
+                "sha256:be18700d55e63a7cdc9e92a5592196105b8787859f21058f7972989e9c7153a1",
+                "sha256:be73e5592a392fcb255d1e161cdfa4e78e0f9d3a9da6d9cf1cb3a2e11d110763",
+                "sha256:bfb6a285c9a803540dcf3d1d4dfb99420c8ea0cf5fce89bf89abddd79b630252",
+                "sha256:c51adab2bb16850f4bc6ac51c7d753d3f7d08ad6005802bd31e4657873f5c94c",
+                "sha256:c63b4add6cb4dc9d2998ab523c259a30b6f1d28651b39a10e0b128abd05544b4",
+                "sha256:c83de7177df8d47263494c03670e3b8a8e7b99864c1123c1efb836f6c96755cc",
+                "sha256:c988766c3076ca2360ba7b41ed4df903a810e20e84b58fd00878865558dafe6f",
+                "sha256:d33d8868898bbbf8f6ae28af8659eb6b182ae1599feb3ef47237c6393366fbc9",
+                "sha256:d5843b827d48d16e1f0d2c8e93c62a10cda71f509b5a49947bb61fcb19d7abce",
+                "sha256:d744dfc4841022505279a7d33c19247f93570e023c15202b2c32e98f61eeaed3",
+                "sha256:d8e9244d1f115f29f14a261b8a03f2d8932a8dc1ff066c5b362df2d56c0e5109",
+                "sha256:ddd2fc8b37641d7ac0c6bd085bc6c036b64337a2b7065044c5cc76e74824c36e",
+                "sha256:de5ffed29aa4461e269a7567211e730ec20eec0b47a87854639cd69fbe8c3e9f",
+                "sha256:e1c542d43857f75209e3f36354ad6846d143cfc0fe71886d661cd9ec5388cdef",
+                "sha256:e47f484e7302c804fb002f8a7b9749e4a51a412449b6a39ca31ff23b889d3fc3",
+                "sha256:e5e71fffd7ef3716d7df4338432dbd60ca2d81ad2830ff97ed4c6aea563f47d3",
+                "sha256:e722759a66aa571c801cec3777412f1172380c5d5761637f22d920893d24d194",
+                "sha256:e835aa2c484ac5d8d1b6c2efefbbbf1bbe2f48ed8adec9c42d6f2df2eb07f93d",
+                "sha256:ea3d22795f09e8cd4c4ac5ff2fe50fa32bd01fa2b48ac5d46479082325d40680",
+                "sha256:ef29fa64514a17bbc104693acf094e3fef5e98c2ddf58e9777f673fc6b0c5e97",
+                "sha256:f177934d33c7b649dc99663642b1a33094af3447e00eb9a1e3eebd9b02ac2158",
+                "sha256:f3da48aee9e0e5567a3bd23a5ee5cc9457fb60cf7af2ecb8b64317fedfc95231",
+                "sha256:f64fdf846e42d77e0dd4dfb90b335f01b2b35aef470b81393c71ce0dd2781eab",
+                "sha256:f9763c409a2aa111fc0f7bb8cda00e2e3bcbac64830f9f529753d635d1ee8d56",
+                "sha256:fa6f798ae72572d35eddd3bed98c91d7c74b218d4ed6ce8d729639dcb7d063af",
+                "sha256:fb586379ddb3418099fce5949fae1377ecc47139aa34c450d7018ff9a995aeb7",
+                "sha256:fd817f2d213c6f1ee104f4805812c6e348984769f15404382ab885a9f2a9e56f",
+                "sha256:fde3feff99b8d83708cd828efc0603e7d92e447bf01b30b72448e411645cc8e8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.8.8"
+            "version": "==0.8.11"
         },
         "secure": {
             "hashes": [
@@ -1188,6 +1244,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "sniffio": {
+            "hashes": [
+                "sha256:e60305c5e5d314f5389259b7f22aaa33d8f7dee49763119234af3755c55b9101",
+                "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.3.0"
         },
         "tzdata": {
             "hashes": [
@@ -1304,11 +1368,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
-                "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"
+                "sha256:679e51dd4403591b2d6838a48de3d283f3d188412a9782faadf845f298736ba0",
+                "sha256:ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"
             ],
-            "markers": "python_version >= '3.7'",
-            "version": "==3.15.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==3.16.2"
         },
         "zope.event": {
             "hashes": [
@@ -1358,11 +1422,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:078e5212f9885fa85fbb0cf0101978a336190aadea6e13305409d099f71b2324",
-                "sha256:1039262575027b441137ab4a62a793a9b43defb42c32d5670f38686207cd780f"
+                "sha256:389656ca57b6108f939cf5d2f9a2a825a3be50ba9d589670f393236e0a03b91c",
+                "sha256:903f024859b7c7687d7a7f3a3f73b17301f8e42dfd9cc9df9d4418172d3e2dbd"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.15.5"
+            "version": "==2.15.6"
         },
         "autopep8": {
             "hashes": [
@@ -1496,11 +1560,11 @@
         },
         "gitpython": {
             "hashes": [
-                "sha256:8ce3bcf69adfdf7c7d503e78fd3b1c492af782d58893b650adb2ac8912ddd573",
-                "sha256:f04893614f6aa713a60cbbe1e6a97403ef633103cdd0ef5eb6efe0deb98dbe8d"
+                "sha256:8d9b8cb1e80b9735e8717c9362079d3ce4c6e5ddeebedd0361b228c3a67a62f6",
+                "sha256:e3d59b1c2c6ebb9dfa7a184daf3b6dd4914237e7488a1730a6d8f6f5d0b4187f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.1.31"
+            "version": "==3.1.32"
         },
         "isort": {
             "hashes": [
@@ -1586,11 +1650,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc",
-                "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"
+                "sha256:1b42b450ad933e981d56e59f1b97495428c9bd60698baab9f3eb3d00d5822421",
+                "sha256:ad8291ae0ae5072f66c16945166cb11c63394c7a3ad1b1bc9828ca3162da8c2f"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.8.0"
+            "version": "==3.9.1"
         },
         "pycodestyle": {
             "hashes": [

--- a/app/services/notifier/base.py
+++ b/app/services/notifier/base.py
@@ -1,13 +1,20 @@
 from datetime import datetime
 import logging
+import json
 import time
 import pymsteams
 import chevron
 import requests
+import smtplib
+import ssl
+import markdown
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
 from jinja2 import Environment
+from jinja2.exceptions import UndefinedError as JinjaUndefinedError
 from pdpyras import EventsAPISession
 from requests.exceptions import ConnectionError
-from app.api_v2.model import Notification, NotificationChannel, NOTIFICATION_CHANNEL_TYPES, SOURCE_OBJECT_TYPE, Event, Case, Settings, Credential
+from app.api_v2.model import Notification, NotificationChannel, NOTIFICATION_CHANNEL_TYPES, SOURCE_OBJECT_TYPE, Event, Case, Settings, Credential, Detection
 
 
 class Notifier(object):
@@ -107,7 +114,7 @@ class Notifier(object):
                     pass
 
 
-    def send_email(self, sender: str, users: list, subject: str, recipients: list = []):
+    def send_email(self, channel, notification):
         '''
         Sends an email to a target user
         '''
@@ -119,10 +126,57 @@ class Notifier(object):
         users = User.get_by_uuid(uuid=uuids)
         [recipients.append(u.email) for u in users]
         """
-        raise NotImplementedError
 
+        channel_config = channel.email_configuration
+        message_template = channel_config['message_template']
+        credential = Credential.get_by_uuid(channel_config['credential'])
+        if credential:
+            try:
+                secret = credential.decrypt(secret=self.app.config['MASTER_PASSWORD'])
+            except:
+                self.logger.error(f"Unable to decrypt credential {credential.uuid}")
+                notification.send_failed(message=f"Unable to decrypt credential {credential.uuid}")
 
-    
+            if hasattr(notification, 'source_object_type') and hasattr(notification, 'source_object_uuid'):
+                if notification.source_object_type not in ['', None] and notification.source_object_uuid not in ['', None]:
+                    notification.message = self.use_template(message_template, notification.source_object_type, notification.source_object_uuid)
+
+        subject = self.use_template(channel_config['subject'], notification.source_object_type, notification.source_object_uuid, skip_detection=True)
+
+        # Create the base message
+        try:
+            message = MIMEMultipart("alternative")
+            message["Subject"] = subject
+            message["From"] = channel_config['mail_from']
+            message["To"] = ','.join(channel_config['mail_to'])
+
+            # Create the plain-text and HTML version of your message
+            text = notification.message
+
+            part1 = MIMEText(text, "plain")
+            part2 = MIMEText(markdown.markdown(text), "html")
+
+            message.attach(part1)
+            message.attach(part2)
+
+            # If the mail server requires TLS
+            if 'use_tls' in channel_config and channel_config['use_tls']:
+                context = ssl.create_default_context()
+                
+                with smtplib.SMTP_SSL(channel_config['smtp_server'], channel_config['smtp_port'], context=context) as server:
+                    #if 'credential' in channel_config:
+                    #    server.login(channel_config['username'], secret)
+                    server.sendmail(channel_config['mail_from'], channel_config['mail_to'], message.as_string())
+            else:
+                with smtplib.SMTP(channel_config['smtp_server'], channel_config['smtp_port']) as server:
+                    #if 'credential' in channel_config:
+                    #    server.login(channel_config['username'], secret)
+                    server.sendmail(channel_config['mail_from'], channel_config['mail_to'], message.as_string())
+        except Exception as e:
+            notification.send_failed(message=f"Unable to send email: {e}")
+        
+        notification.send_success()
+
 
     def get_channels(self, notification):
         '''
@@ -185,17 +239,37 @@ class Notifier(object):
 
         message = ""
         environment = Environment()
-        jinja_template = environment.from_string(template)
 
         if source_object_type in SOURCE_OBJECT_TYPE:
             source_object = None
             source_object = OBJECT_MAP[source_object_type].get_by_uuid(uuid=source_object_uuid)
-            if source_object:
-                message = jinja_template.render(source_object.to_dict())
+
+            if 'skip_detection' in kwargs and kwargs['skip_detection']:
+                pass
+
+            else:
+                if hasattr(source_object, 'detection_id'):
+                    detection = Detection.get_by_uuid(uuid=source_object.detection_id)
+                    if detection:
+                        if hasattr(detection, 'email_template'):
+                            template = detection.email_template
+
+            jinja_template = environment.from_string(template)
+                            
+            if source_object:                
+
+                source_dict = source_object.to_dict()
+                if 'raw_log' in source_dict:
+                    source_dict['raw_log'] = json.loads(source_dict['raw_log'])
+                try:
+                    message = jinja_template.render(source_dict)
+                except JinjaUndefinedError as e:
+                    message = template + "\n\n" + f"Error parsing source object: {str(e)}"
+
                 #message = chevron.render(template, source_object.to_dict())
                 return message
 
-        return template       
+        return template
 
     
     def send_pagerduty_api(self, channel, notification):

--- a/app/services/notifier/base.py
+++ b/app/services/notifier/base.py
@@ -159,19 +159,26 @@ class Notifier(object):
             message.attach(part1)
             message.attach(part2)
 
+            connection = smtplib.SMTP(channel_config['smtp_server'], channel_config['smtp_port'])
+
             # If the mail server requires TLS
             if 'use_tls' in channel_config and channel_config['use_tls']:
-                context = ssl.create_default_context()
+                context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+
+                connection.ehlo()
+                connection.starttls(context=context)
+                connection.ehlo()
                 
-                with smtplib.SMTP_SSL(channel_config['smtp_server'], channel_config['smtp_port'], context=context) as server:
-                    #if 'credential' in channel_config:
-                    #    server.login(channel_config['username'], secret)
-                    server.sendmail(channel_config['mail_from'], channel_config['mail_to'], message.as_string())
+                if 'credential' in channel_config:
+                    connection.login(credential.username, secret)
+
+                connection.sendmail(channel_config['mail_from'], channel_config['mail_to'], message.as_string())
             else:
-                with smtplib.SMTP(channel_config['smtp_server'], channel_config['smtp_port']) as server:
-                    #if 'credential' in channel_config:
-                    #    server.login(channel_config['username'], secret)
-                    server.sendmail(channel_config['mail_from'], channel_config['mail_to'], message.as_string())
+                
+                
+                if 'credential' in channel_config:
+                    connection.login(credential.username, secret)
+                connection.sendmail(channel_config['mail_from'], channel_config['mail_to'], message.as_string())
         except Exception as e:
             notification.send_failed(message=f"Unable to send email: {e}")
         


### PR DESCRIPTION
Adds support for e-mail notifications via Event Rules:

1. Create a new Email Notification channel
2. Create a new Event Rule with the proper event criteria and link it to the Notification channel

By default the notification will use the message template defined in the channel, however if the Event being sent has an Email Template configured in the Detection rule it originated from, that will be used instead.